### PR TITLE
Bed range check

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 </picture>
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7271099.svg)](https://doi.org/10.5281/zenodo.7271099)
+[![DOI:10.1101/2022.11.01.514708](http://img.shields.io/badge/DOI-10.1101/2022.11.01.514708-B31B1b.svg)](https://doi.org/10.1101/2022.11.01.514708)
 
 # Automated RenSeq workflows with Snakemake
 

--- a/README.md
+++ b/README.md
@@ -27,14 +27,16 @@ There are a few things you need to set up prior to running the workflow with Sna
 conda install mamba
 ```
 
-You will also need to install pandas
+You will also need to install pandas and biopython
 
 ```bash
 # With mamba
 mamba install pandas
+mamba install biopython
 
 # With base conda
 conda install pandas
+conda install biopython
 ```
 
 2.  Install Snakemake into your base conda environment

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -11,13 +11,14 @@ if samples.duplicated(subset=["sample"]).any():
 with open(config["CDS_Bed"]) as bed:
     bed_lines = bed.readlines()
     for gene in SeqIO.parse(config["Reference_Fasta"], "fasta"):
-        name = gene.id
+        fasta_name = gene.id
         fasta_length = len(gene.seq)
         for bed_line in bed_lines:
             bed_line = bed_line.rstrip()
             split_bed_line = bed_line.split()
-            if split_bed_line[0] == name:
-                bed_length = split_bed_line[2]
+            bed_name = split_bed_line[0]
+            if bed_name == fasta_name:
+                bed_length = int(split_bed_line[2])
                 if bed_length > fasta_length:
                     sys.exit("Bed file co-ordinates are out of range of your fasta file, check your inputs!")
 

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -1,4 +1,5 @@
 import pandas as pd
+from Bio import SeqIO
 
 configfile: "config/config.yaml"
 
@@ -6,6 +7,8 @@ samples=pd.read_table(config["samples"], header=0).set_index(["sample"], drop=Fa
 
 if samples.duplicated(subset=["sample"]).any():
     sys.exit("Duplicate sample in samples file, check your inputs!")
+
+
 
 
 def get_F_Reads(wildcards):

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -17,7 +17,7 @@ with open(config["CDS_Bed"]) as bed:
             bed_line = bed_line.rstrip()
             split_bed_line = bed_line.split()
             if split_bed_line[0] == name:
-                bed_length = split_bed_line[3]
+                bed_length = split_bed_line[2]
                 if bed_length > fasta_length:
                     sys.exit("Bed file co-ordinates are out of range of your fasta file, check your inputs!")
 

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -8,7 +8,18 @@ samples=pd.read_table(config["samples"], header=0).set_index(["sample"], drop=Fa
 if samples.duplicated(subset=["sample"]).any():
     sys.exit("Duplicate sample in samples file, check your inputs!")
 
-
+with open(config["CDS_Bed"]) as bed:
+    bed_lines = bed.readlines()
+    for gene in SeqIO.parse(config["Reference_Fasta"], "fasta"):
+        name = gene.id
+        fasta_length = len(gene.seq)
+        for bed_line in bed_lines:
+            bed_line = bed_line.rstrip()
+            split_bed_line = bed_line.split()
+            if split_bed_line[0] == name:
+                bed_length = split_bed_line[3]
+                if bed_length > fasta_length:
+                    sys.exit("Bed file co-ordinates are out of range of your fasta file, check your inputs!")
 
 
 def get_F_Reads(wildcards):

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -8,20 +8,16 @@ samples=pd.read_table(config["samples"], header=0).set_index(["sample"], drop=Fa
 if samples.duplicated(subset=["sample"]).any():
     sys.exit("Duplicate sample in samples file, check your inputs!")
 
+bed_dict = {}
 with open(config["CDS_Bed"]) as bed:
-    bed_lines = bed.readlines()
-    for gene in SeqIO.parse(config["Reference_Fasta"], "fasta"):
-        fasta_name = gene.id
-        fasta_length = len(gene.seq)
-        for bed_line in bed_lines:
-            bed_line = bed_line.rstrip()
-            split_bed_line = bed_line.split()
-            bed_name = split_bed_line[0]
-            if bed_name == fasta_name:
-                bed_length = int(split_bed_line[2])
-                if bed_length > fasta_length:
-                    sys.exit("Bed file co-ordinates are out of range of your fasta file, check your inputs!")
+    for line in bed.readlines():
+        line = line.rstrip()
+        line_split = line.split()
+        bed_dict[line_split[0]] = int(line_split[2])
 
+for gene in SeqIO.parse(config["Reference_Fasta"], "fasta"):
+    if bed_dict[gene.id] > len(gene.seq):
+        sys.exit("Bed file co-ordinates are out of range of your fasta file, check your inputs!")
 
 def get_F_Reads(wildcards):
     return samples["FRead"][wildcards.sample]


### PR DESCRIPTION
This PR adds a check to the dRenSeq workflow to ensure all co-ordinates provided in the CDS Bed are within the range of bases in the fasta file. If not, the workflow exits.

In it's current state, the workflow simply reports this gene as having zero coverage, which could be seen as a false negative.