### PR TITLE
Corrects typo in checking for duplications in samples file

### DIFF
--- a/smrtrenseq_assembly/workflow/Snakefile
+++ b/smrtrenseq_assembly/workflow/Snakefile
@@ -4,7 +4,7 @@ configfile: "config/config.yaml"
 
 samples = pd.read_table(config["samples"], header=0).set_index(["sample"], drop=False)
 
-if samples.duplciated(subset=["sample"]).any():
+if samples.duplicated(subset=["sample"]).any():
     sys.exit("Duplicate sample in samples file, check your inputs!")
 
 


### PR DESCRIPTION
Typo was present in smrtrenseq assembly workflow. This corrects it.