### PR TITLE
Minor bug fix

### DIFF
--- a/agrenseq/README.md
+++ b/agrenseq/README.md
@@ -15,8 +15,8 @@ All input files and parameters are handled by the config file `config/config.yam
 *   `assoc_threshold` integer value of the threshold used to filter contigs by agrenseq association, and plot on the BLAST plot
 
 Paths may be absolute or relative to the directory that `snakemake` is executed from.
-It is recommended to execute the workflow from the `agrenseq/` directory.
-It's recommended to keep all metadata files in the config directory to keep it tidy.
+This workflow MUST be executed from the base `agrenseq/` directory.
+It's recommended to keep all metadata files in the config directory to keep it tidy!
 
 ### Input data
 

--- a/agrenseq/workflow/rules/phenotype.smk
+++ b/agrenseq/workflow/rules/phenotype.smk
@@ -1,6 +1,6 @@
 rule phenotype:
     input:
-        "config/read_scores.txt"
+        config["read_scores"]
     output:
         temp("results/phenotype.txt")
     threads:


### PR DESCRIPTION
The read scores file for agrenseq was hardcoded into the phenotyping rule, rather than using the file provided by the user in config. This has been updated.

Adjusted the README of agrenseq to make it clear that it must be run from the agrenseq directory!