### PR TITLE
Always point to latest zenodo version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <img alt="Logo" src="assets/HISSlogo_dark.png">
 </picture>
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7380312.svg)](https://doi.org/10.5281/zenodo.7380312)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7271098.svg)](https://doi.org/10.5281/zenodo.7271098)
 
 [![DOI:10.1101/2022.11.01.514708](http://img.shields.io/badge/DOI-10.1101/2022.11.01.514708-B31B1b.svg)](https://doi.org/10.1101/2022.11.01.514708)
 


### PR DESCRIPTION
DOI will now always point to the latest version