### PR TITLE
Handle multiple nlrs per contig

### DIFF
--- a/Example_Workflow.md
+++ b/Example_Workflow.md
@@ -71,15 +71,6 @@ awk '/^>/ {printf("\n%s\n",$0);next; } { printf("%s",$0);}  END {printf("\n");}'
 
 cat ../smrtrenseq_assembly/assembly/Gemson/Gemson_unwrapped.contigs.fasta | grep -A1 -f ../agrenseq/results/Gemson_filtered_contigs.txt | sed 's/--//g' | sed '/^$/d' | sed '/^>/ s/ .*//' >> config/Gemson_candidates.fa # get your sequences for contigs you want, we have provided example sequences to aid in running the analysis
 
-cat ../smrtrenseq_assembly/NLR_Annotator/Gemson_NLR_Annotator.txt | grep -f ../agrenseq/results/Gemson_filtered_contigs.txt | less -S # See how many nlrs per contig
-
-# Manually fix file in your favourite text editor - this example uses nano
-# If you only have one NLR per contig, simply append the contig names with _nlr_1
-# If you have more than one NLR per contig, you will need to add the seqeuence multiple times, giving separate sequences for nlr_1, nlr_2 etc.
-# Lines can be cut with the shortcut Ctrl + K (copied with Alt + ^ ) and paste
-# with Ctrl + U . To cut or copy multiple lines press the shortcut multiple times.
-nano config/Gemson_candidates.fa
-
 cat ../smrtrenseq_assembly/NLR_Annotator/Gemson_NLR_Annotator.txt | grep -f ../agrenseq/results/Gemson_filtered_contigs.txt | cut -f2,4-5 >> config/Gemson_candidates.bed # Make a bed file, we have provided example sequences to aid in running the analysis
 
 # Run workflow

--- a/Example_Workflow.md
+++ b/Example_Workflow.md
@@ -71,7 +71,7 @@ awk '/^>/ {printf("\n%s\n",$0);next; } { printf("%s",$0);}  END {printf("\n");}'
 
 cat ../smrtrenseq_assembly/assembly/Gemson/Gemson_unwrapped.contigs.fasta | grep -A1 -f ../agrenseq/results/Gemson_filtered_contigs.txt | sed 's/--//g' | sed '/^$/d' | sed '/^>/ s/ .*//' >> config/Gemson_candidates.fa # get your sequences for contigs you want, we have provided example sequences to aid in running the analysis
 
-cat ../smrtrenseq_assembly/NLR_Annotator/Gemson_NLR_Annotator.txt | grep -f ../agrenseq/results/Gemson_filtered_contigs.txt | cut -f2,4-5 >> config/Gemson_candidates.bed # Make a bed file, we have provided example sequences to aid in running the analysis
+cat ../smrtrenseq_assembly/NLR_Annotator/Gemson_NLR_Annotator_sorted.bed | grep -f ../agrenseq/results/Gemson_filtered_contigs.txt | cut -f1-4 >> config/Gemson_candidates.bed # Make a bed file, we have provided example sequences to aid in running the analysis
 
 # Run workflow
 # If using a cluster profile

--- a/drenseq/README.md
+++ b/drenseq/README.md
@@ -30,7 +30,7 @@ Ensure this contains regions outside the CDS too, this ensures alignments are pe
 
 #### CDS_Bed
 
-A BED file of the CDS regions of your targets.
+A BED file of the CDS regions of your targets. Consisting of field one of the contig name, the start of the CDS region in column 2, the end of the CDS region in column 3 and the nlr name in column 4. See the example workflow for how to easily parse this from your NLR Annotator bed file.
 
 #### samples
 

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -252,6 +252,7 @@ rule nlr_annotator_baits:
     shell:
         "(bedtools intersect -a {input.nlr_annotator_region} -b {input.baits_region} > {output}) 2> {log}"
 
+
 rule coverage_strict:
     input:
         bam="mappings/{sample}_strict.bam",

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -220,6 +220,7 @@ rule baits_mapping:
         (blastn -db "baits_mapping/baits_mapping_db" -query {input.baits} -out {output} -perc_identity {params.identity} -qcov_hsp_perc {params.coverage} -evalue 1e-5 -outfmt '6 qseqid sseqid pident length mismatch gapopen qstart qend sstart send evalue bitscore qlen len qcovs qcovhsp' -num_threads 2) 2> {log}
         """
 
+
 rule baits_region:
     input:
         blast="baits_mapping/baits_blast.txt"

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -282,7 +282,7 @@ rule per_gene_coverage:
     resources:
         mem_mb=2000
     shell:
-        """(cat {input.referenceGenes} | tail -n +2 | while read gene; do numPosWithCoverage=`grep -w "$gene" {input.sample_coverage} | awk '$5>0' | wc -l`; numPosTotal=`grep -w "$gene" {input.sample_coverage} | wc -l`; if [ $numPosTotal -eq 0 ]; then echo "ERROR: gene $gene has CDS region of length zero. Check your input data (e.g. gene spelling in FASTA and CDS BED file) and retry.\nAborting pipeline run." > {log}; exit; fi; pctCov=`awk "BEGIN {{print ($numPosWithCoverage/$numPosTotal)*100 }}"`; echo -e "\n# covered positions for sample {wildcards.sample} in gene $gene: $numPosWithCoverage\n# CDS positions for gene $gene: $numPosTotal\npctCov: $pctCov" >> {log}; echo -e "$gene\t$pctCov" >> {output.gene_coverage}; done) 2>> {log}"""
+        """(cat {input.referenceGenes} | tail -n +2 | while read gene; do numPosWithCoverage=`grep -w "$gene" {input.sample_coverage} | awk '$6>0' | wc -l`; numPosTotal=`grep -w "$gene" {input.sample_coverage} | wc -l`; if [ $numPosTotal -eq 0 ]; then echo "ERROR: gene $gene has CDS region of length zero. Check your input data (e.g. gene spelling in FASTA and CDS BED file) and retry.\nAborting pipeline run." > {log}; exit; fi; pctCov=`awk "BEGIN {{print ($numPosWithCoverage/$numPosTotal)*100 }}"`; echo -e "\n# covered positions for sample {wildcards.sample} in gene $gene: $numPosWithCoverage\n# CDS positions for gene $gene: $numPosTotal\npctCov: $pctCov" >> {log}; echo -e "$gene\t$pctCov" >> {output.gene_coverage}; done) 2>> {log}"""
 
 
 rule combine_gene_coverage:

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -39,7 +39,7 @@ rule all:
 
 rule extract_reference_headers:
     input:
-        config["Reference_Fasta"]
+        config["CDS_Bed"]
     output:
         "resources/reference_headers.txt"
     log:
@@ -48,7 +48,7 @@ rule extract_reference_headers:
         mem_mb=2000
     run:
         shell("""echo "gene" > {output}""")
-        shell("""(cat {input} | grep '>' | sed 's/>//g' >> {output}) 2> {log}""")
+        shell("""(cat {input} | cut -f4 >> {output}) 2> {log}""")
 
 
 rule trim_read_remove_adaptor:

--- a/example_inputs/drenseq/Gemson_candidates.bed
+++ b/example_inputs/drenseq/Gemson_candidates.bed
@@ -1,6 +1,6 @@
-Rpi_R9a 3313    5905
-Rpi_R8  1679    5417
-Rpi_R3b 250     4102
-Rpi_R3a 3324    7173
-Rpi_R2-like     250     2794
-Rpi_R1  1061    5163
+Rpi_R9a	3313	5905	Rpi_R9a
+Rpi_R8	1679	5417	Rpi_R8
+Rpi_R3b	250	4102	Rpi_R3b
+Rpi_R3a	3324	7173	Rpi_R3a
+Rpi_R2-like	250	2794	Rpi_R2-like
+Rpi_R1	1061	5163	Rpi_R1


### PR DESCRIPTION
A few small changes to the dRenSeq workflow and the requirements for the input bed file mean it is no longer necessary to duplicate sequences in the fasta file as a workaround where multiple nlrs exist on a contig.