### PR TITLE
Improve logging drenseq blast

### DIFF
--- a/drenseq/workflow/script/RangeReduction.R
+++ b/drenseq/workflow/script/RangeReduction.R
@@ -21,6 +21,7 @@ colnames(infile) <- c("contig", "start", "end")
 # Check all input genes have at least one blast hit from the baits
 
 contigs <- as.list(unique(infile$contig))
+targets_file <- read.csv(reference_headers, header = TRUE)
 
 # Ensure all starts and stops are relative to the + strand
 

--- a/drenseq/workflow/script/RangeReduction.R
+++ b/drenseq/workflow/script/RangeReduction.R
@@ -10,6 +10,7 @@ args <- commandArgs(TRUE)
 input <- args[1]
 output <- args[2]
 flanking_region <- args[3]
+reference_headers <- args[4]
 
 # Read in input BLAST results
 

--- a/drenseq/workflow/script/RangeReduction.R
+++ b/drenseq/workflow/script/RangeReduction.R
@@ -31,7 +31,7 @@ if (all(input_headers %in% contig_names)) {
     print("The workflow will fail if allowed to continue.")
     print("The workflow will now be ended.")
     print("Check the input sequences and remove those that have no bait hits")
-    quit(save = "no", status = 1)
+    quit(save = "no", status = 10)
 }
 
 # Ensure all starts and stops are relative to the + strand

--- a/drenseq/workflow/script/RangeReduction.R
+++ b/drenseq/workflow/script/RangeReduction.R
@@ -22,6 +22,17 @@ colnames(infile) <- c("contig", "start", "end")
 
 contig_names <- unique(infile$contig)
 targets_file <- read.csv(reference_headers, header = TRUE)
+input_headers <- unique(targets_file$gene)
+
+if (all(input_headers %in% contig_names)) {
+    print("All sequences have a bait hit")
+} else {
+    print("At least one of your sequences does not have a bait hit from blast.")
+    print("The workflow will fail if allowed to continue.")
+    print("The workflow will now be ended.")
+    print("Check the input sequences and remove those that have no bait hits")
+    quit(save = "no", status = 1)
+}
 
 # Ensure all starts and stops are relative to the + strand
 

--- a/drenseq/workflow/script/RangeReduction.R
+++ b/drenseq/workflow/script/RangeReduction.R
@@ -20,7 +20,7 @@ colnames(infile) <- c("contig", "start", "end")
 
 # Check all input genes have at least one blast hit from the baits
 
-contigs <- as.list(unique(infile$contig))
+contig_names <- unique(infile$contig)
 targets_file <- read.csv(reference_headers, header = TRUE)
 
 # Ensure all starts and stops are relative to the + strand
@@ -37,6 +37,8 @@ swap_if <- function(a, b, d, missing = NA) {
 swapped <- swap_if(infile$start, infile$end, infile$contig)
 
 # Extract all regions with overlapping bait sequences and putative NLRs
+
+contigs <- as.list(unique(infile$contig))
 
 bedfile <- data.frame(IRanges())
 

--- a/drenseq/workflow/script/RangeReduction.R
+++ b/drenseq/workflow/script/RangeReduction.R
@@ -18,6 +18,8 @@ infile <- read.csv(input, header = FALSE, sep = "\t")
 infile <- infile[, c(2, 9, 10)]
 colnames(infile) <- c("contig", "start", "end")
 
+# Check all input genes have at least one blast hit from the baits
+
 # Ensure all starts and stops are relative to the + strand
 
 swap_if <- function(a, b, d, missing = NA) {

--- a/drenseq/workflow/script/RangeReduction.R
+++ b/drenseq/workflow/script/RangeReduction.R
@@ -20,6 +20,8 @@ colnames(infile) <- c("contig", "start", "end")
 
 # Check all input genes have at least one blast hit from the baits
 
+contigs <- as.list(unique(infile$contig))
+
 # Ensure all starts and stops are relative to the + strand
 
 swap_if <- function(a, b, d, missing = NA) {
@@ -32,11 +34,6 @@ swap_if <- function(a, b, d, missing = NA) {
     }
 
 swapped <- swap_if(infile$start, infile$end, infile$contig)
-
-# Create list of all contigs in the file and make any modifications for
-# flanking regions
-
-contigs <- as.list(unique(infile$contig))
 
 # Extract all regions with overlapping bait sequences and putative NLRs
 


### PR DESCRIPTION
While running v2.0.0 an error was encountered if a gene to be analysed has no BLAST hits. in v2.0.0 this is not clearly communicated in the logs. This PR adds a checking function to RangeReduction.R and exits with an error status if no gene has a bait hitting, causing the whole workflow to stop. This should make it more clear to users how to fix the problem.

@SwiftSeal can you check my R code is okay and then merge it?