### PR TITLE
Corrects python script for creating sorted NLR bed

### DIFF
--- a/smrtrenseq_assembly/workflow/scripts/NLR_Annotator_to_bed.py
+++ b/smrtrenseq_assembly/workflow/scripts/NLR_Annotator_to_bed.py
@@ -28,7 +28,7 @@ def load_file(input: list):
         line = line.rstrip()
         split_line = line.split('\t')
         contig = split_line[0]
-        start = int(split_line[3]) - 1
+        start = int(split_line[3])
         end = split_line[4]
         gene_ID = split_line[1]
         score = 0


### PR DESCRIPTION
This patches an error. The NLR Annotator text output is already zero based for start positions, so it doesn't need recalculating like it does from a gff file.