### PR TITLE
Large read sets failed out with memory errors, increased memory here …

### DIFF
--- a/smrtrenseq_assembly/workflow/Snakefile
+++ b/smrtrenseq_assembly/workflow/Snakefile
@@ -63,11 +63,11 @@ rule canu_assemble:
     conda:
         "envs/canu.yaml"
     resources:
-        mem_mb = 10000,
-        partition = "medium"
+        mem_mb = 32000,
+        partition = "long"
     shell:
         """
-        canu -d assembly/{wildcards.sample} -p {params.Prefix} -pacbio-hifi {input} useGrid=false genomeSize={params.Genome_Size} maxInputCoverage=10000
+        canu -d assembly/{wildcards.sample} -p {params.Prefix} -pacbio-hifi {input} useGrid=false genomeSize={params.Genome_Size} maxInputCoverage=10000 batMemory=32g
         """
 
 


### PR DESCRIPTION
…to ensure jobs run.

This deals with an internal job failing when one the read sets was too large.