### PR TITLE
Snakemake v8 compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ There are a few things you need to set up prior to running the workflow with Sna
 
 1.  Install either Anaconda or Miniconda, Miniconda is more lightweight so we recommend this option. <https://docs.conda.io/en/latest/miniconda.html>
 
-    We also recommend installing the alternative dependency resolver mamba, it's the default for Snakemake and is far quicker than base conda <https://anaconda.org/conda-forge/mamba>. Please note some users have reported issues with mamba, if you experience these please try reverting to the default conda resolver.
+    We also recommend installing the alternative dependency resolver mamba, it's the default for Snakemake and is far quicker than base conda <https://anaconda.org/conda-forge/mamba>. Please note some users have reported issues with mamba, if you experience these please try reverting to the base conda resolver. You can force the workflow to use the base resolver with the --conda-frontend conda option.
 
 ```bash
 conda install mamba

--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ conda install cookiecutter
 **NOTE: these Snakefiles have some rules with explicitly specified queue names tailored for the cluster system it was developed on.
 You will likely need to change this for optimal resource usage and to comply with your local queue policies.**
 
+You may also need to modify your profile, the test environment utilised slurm and required the following changes to the slurm profile to provide compatability with snakemake v8.0 and above
+
+```
+cluster: "slurm-submit.py" changed to cluster-generic-submit-cmd: "slurm-submit.py"
+cluster-cancel: "scancel" changed to cluster-generic-cancel-cmd: "scancel"
+cluster-status: "slurm-status.py" changed to cluster-generic-status-cmd: "slurm-status.py"
+cluster-sidecar: "slurm-sidecar.py" changed to cluster-generic-sidecar-cmd; "slurm-sidecar.py"
+```
+
 ### Recommended - Run checks that your configuration is correct
 
 Snakemake has inbuilt methods to do dry-runs and report the jobs it will run, it can also produce a graphical representation of its dependency graph, though the usefulness of this will decrease as your sample number increases.

--- a/README.md
+++ b/README.md
@@ -49,9 +49,12 @@ mamba install snakemake
 # If using only base conda
 conda install snakemake
 ```
-3.  If running in a cluster environment, create a profile
+
+3.  If running in a cluster environment, install the executor and create a profile
 
 Snakemake is able to leverage your clusters job scheduler to submit and monitor the jobs it runs. This can be done manually, but many profiles are already available at <https://github.com/Snakemake-Profiles>. These require cookiecutter to be installed as described below. Ensure that your created profile defaults to use conda to leverage the conda yamls provided by the workflow. Ensure you also set a sensible maximum number of simultaneous jobs. The specific value will depend on your clusters capacity.
+
+As of Snakemake v8.0, you also need to install the executor for your job scheduler, you can find these at <https://snakemake.github.io/snakemake-plugin-catalog/index.html>. The test environment also had the snakemake-executor-plugin-cluster-generic installed alongside a specific plugin for the job scheduler.
 
 ```bash
 # Using mamba
@@ -62,9 +65,11 @@ mamba install cookiecutter
 # Using base conda
 
 conda install cookiecutter
+
+# Then follow the instructions for the relevant executors and profiles
 ```
 
-**NOTE: this Snakefile has some rules with explicitly specified queue names tailored for the cluster system it is devloped on.
+**NOTE: these Snakefiles have some rules with explicitly specified queue names tailored for the cluster system it was developed on.
 You will likely need to change this for optimal resource usage and to comply with your local queue policies.**
 
 ### Recommended - Run checks that your configuration is correct

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ In cluster mode you can force a rule to override the default queue by adding the
 
 ```
     resources:
-        partition="partition"
+        slurm_partition="partition"
 ```
 
 Some rules have explicit memory limits set in the resources sections, you may need to change these depending on your input files or your cluster specification.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Any errors or warnings will be given as red text if your terminal emulator suppo
 
 1.  Perform a basic dry run of your workflow
 
-For cluster mode, replace /path/to/your/cluster/profile with the directory where your cluster specification you made above is. Also replace name_of_installed_executor with the executor you have installed above. You may also wish to set default resources, such as default partitions. This is done with the --default-resources option. See the Snakemake documentation for more details on specific schedulers
+For cluster mode, replace /path/to/your/cluster/profile with the directory where your cluster specification you made above is. Also replace name_of_installed_executor with the executor you have installed above. You may also wish to set default resources, such as default partitions. This is done with the --default-resources option. See the Snakemake documentation for more details on specific schedulers.
 
 For standalone mode, replace the number_of_cores with an integer value for the maximum number of threads Snakemake can use.
 
@@ -115,7 +115,7 @@ If everything passed above, you are ready to run your analysis.
 Keep in mind your Snakemake process MUST keep running whilst all your jobs run, for this reason if you are remote accessing a cluster system we recommend using a terminal multiplexer such as GNU Screen or tmux to keep your session active even if your connection goes down.
 The Snakemake process must also be able to run job submissions (such as sbatch in SLURM) and query job status (such as sacct in SLURM), some cluster implementations will allow this within a scheduled job, others will not, please test your system first or contact your local admin.
 
-For cluster mode, replace /path/to/your/cluster/profile with the directory where your cluster specification you made above is.
+For cluster mode, replace /path/to/your/cluster/profile with the directory where your cluster specification you made above is. Also replace name_of_installed_executor with the executor you have installed above. You may also wish to set default resources, such as default partitions. This is done with the --default-resources option. See the Snakemake documentation for more details on specific schedulers.
 In cluster mode you can force a rule to override the default queue by adding the below to your rule.
 
 ```
@@ -133,7 +133,7 @@ Some users have reported that the default mamba frontend in snakemake can cause 
 
 ```bash
 # Cluster mode
-snakemake --profile /path/to/your/cluster/profile
+snakemake --executor name_of_installed_executor --profile /path/to/your/cluster/profile
 
 # Standalone mode (not recommended for large sample counts)
 snakemake --use-conda --cores number_of_cores

--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ Any errors or warnings will be given as red text if your terminal emulator suppo
 
 1.  Perform a basic dry run of your workflow
 
-For cluster mode, replace /path/to/your/cluster/profile with the directory where your cluster specification you made above is.
+For cluster mode, replace /path/to/your/cluster/profile with the directory where your cluster specification you made above is. Also replace name_of_installed_executor with the executor you have installed above. You may also wish to set default resources, such as default partitions. This is done with the --default-resources option. See the Snakemake documentation for more details on specific schedulers
 
 For standalone mode, replace the number_of_cores with an integer value for the maximum number of threads Snakemake can use.
 
 ```bash
 # Cluster mode
-snakemake --dry-run --profile /path/to/your/cluster/profile
+snakemake --dry-run --executor name_of_installed_executor --profile /path/to/your/cluster/profile
 
 # Standalone mode (not recommended for large sample counts)
 snakemake --dry-run --cores number_of_cores

--- a/agrenseq/workflow/rules/accessions.smk
+++ b/agrenseq/workflow/rules/accessions.smk
@@ -7,7 +7,7 @@ rule accessions:
     resources:
         mem_mb = 1000
     log:
-        "logs/accessions/{sample}.log"
+        "logs/accessions/accessions.log"
     run:
         import logging
         logging.basicConfig(filename=str(log), encoding='utf-8', level=logging.DEBUG)

--- a/agrenseq/workflow/rules/accessions.smk
+++ b/agrenseq/workflow/rules/accessions.smk
@@ -10,7 +10,7 @@ rule accessions:
         "logs/accessions/{sample}.log"
     run:
         import logging
-        logging.basicConfig(filename=log, encoding='utf-8', level=logging.DEBUG)
+        logging.basicConfig(filename=str(log), encoding='utf-8', level=logging.DEBUG)
         for f in input:
             with open(output[0], "a") as out:
                 out.write(f"{Path(f).stem}\t{f}\n")

--- a/agrenseq/workflow/rules/accessions.smk
+++ b/agrenseq/workflow/rules/accessions.smk
@@ -10,7 +10,7 @@ rule accessions:
         "logs/accessions/{sample}.log"
     run:
         import logging
-        logging.basicConfig(filename={log}, encoding='utf-8', level=logging.DEBUG)
+        logging.basicConfig(filename=log, encoding='utf-8', level=logging.DEBUG)
         for f in input:
             with open(output[0], "a") as out:
                 out.write(f"{Path(f).stem}\t{f}\n")

--- a/agrenseq/workflow/rules/accessions.smk
+++ b/agrenseq/workflow/rules/accessions.smk
@@ -6,7 +6,11 @@ rule accessions:
         temp("results/accessions.txt")
     resources:
         mem_mb = 1000
+    log:
+        "logs/accessions/{sample}.log"
     run:
+        import logging
+        logging.basicConfig(filename={log}, encoding='utf-8', level=logging.DEBUG)
         for f in input:
             with open(output[0], "a") as out:
                 out.write(f"{Path(f).stem}\t{f}\n")

--- a/agrenseq/workflow/rules/blast.smk
+++ b/agrenseq/workflow/rules/blast.smk
@@ -26,8 +26,8 @@ rule run_blast:
         "../envs/blast.yaml"
     resources:
         mem_mb = 4000,
-        partition = "medium"
+        slurm_partition = "medium"
     shell:
         """
-        blastn -query {input[0]} -db "results/blast/blast" -outfmt 6 -num_threads {threads} | sort -k1,1 -k12,12nr -k11,11n | sort -u -k1,1 --merge > {output.blast_result}
+        blastn -query {input[0]} -db "results/blast/blast" -outfmt 6 -num_threads {threads} | sort -k1,1 -k12,12nr -k11,11n | sort -u -k1,1 --merge 1> {output.blast_result} 2> {log}
         """

--- a/agrenseq/workflow/rules/blast.smk
+++ b/agrenseq/workflow/rules/blast.smk
@@ -7,9 +7,11 @@ rule blast_db:
         "../envs/blast.yaml"
     resources:
         mem_mb = 1000
+    log:
+        "logs/blast_db/makeblastdb.log"
     shell:
         """
-        makeblastdb -in {input.subject} -dbtype nucl -out "results/blast/blast"
+        makeblastdb -in {input.subject} -dbtype nucl -out "results/blast/blast" 2> {log}
         """
 
 rule run_blast:

--- a/agrenseq/workflow/rules/blast.smk
+++ b/agrenseq/workflow/rules/blast.smk
@@ -27,6 +27,8 @@ rule run_blast:
     resources:
         mem_mb = 4000,
         slurm_partition = "medium"
+    log:
+        "logs/run_blast/blastn.log"
     shell:
         """
         blastn -query {input[0]} -db "results/blast/blast" -outfmt 6 -num_threads {threads} | sort -k1,1 -k12,12nr -k11,11n | sort -u -k1,1 --merge 1> {output.blast_result} 2> {log}

--- a/agrenseq/workflow/rules/blast.smk
+++ b/agrenseq/workflow/rules/blast.smk
@@ -28,7 +28,7 @@ rule run_blast:
         mem_mb = 4000,
         slurm_partition = "medium"
     log:
-        "logs/run_blast/blastn.log"
+        "logs/run_blast/{reference}.log"
     shell:
         """
         blastn -query {input[0]} -db "results/blast/blast" -outfmt 6 -num_threads {threads} | sort -k1,1 -k12,12nr -k11,11n | sort -u -k1,1 --merge 1> {output.blast_result} 2> {log}

--- a/agrenseq/workflow/rules/fastp.smk
+++ b/agrenseq/workflow/rules/fastp.smk
@@ -11,7 +11,9 @@ rule fastp:
         mem_mb = 3000
     conda:
         "../envs/fastp.yaml"
+    log:
+        "logs/fastp/{sample}.log"
     shell:
         """
-        fastp -i {input}[0] -I {input}[1] -o {output.R1} -O {output.R2} -j {output.json} -h /dev/null
+        fastp -i {input}[0] -I {input}[1] -o {output.R1} -O {output.R2} -j {output.json} -h /dev/null 2> {log}
         """

--- a/agrenseq/workflow/rules/jellyfish.smk
+++ b/agrenseq/workflow/rules/jellyfish.smk
@@ -11,8 +11,10 @@ rule jellyfish:
         mem_mb = 13000
     conda:
         "../envs/jellyfish.yaml"
+    log:
+        "logs/jellyfish/{sample}.log"
     shell:
         """
-        zcat {input.R1} {input.R2} | jellyfish count /dev/fd/0 -C -m 51 -s 1G -t {threads} -o {output.jf}
-        jellyfish dump -L 10 -ct {output.jf} > {output.dump}
+        zcat {input.R1} {input.R2} | jellyfish count /dev/fd/0 -C -m 51 -s 1G -t {threads} -o {output.jf} 2> {log}
+        jellyfish dump -L 10 -ct {output.jf} 1> {output.dump} 2>> {log}
         """

--- a/agrenseq/workflow/rules/matrix.smk
+++ b/agrenseq/workflow/rules/matrix.smk
@@ -9,7 +9,9 @@ rule matrix:
         mem_mb = 30000
     conda:
         "../envs/java.yaml"
+    log:
+        "logs/matrix/create_presence_matrix.log"
     shell:
         """
-        java -jar ../utils/AgRenSeq_CreatePresenceMatrix.jar -i {input} -o {output} -t 3 -n 10
+        java -jar ../utils/AgRenSeq_CreatePresenceMatrix.jar -i {input} -o {output} -t 3 -n 10 2> {log}
         """

--- a/agrenseq/workflow/rules/nlr_parser.smk
+++ b/agrenseq/workflow/rules/nlr_parser.smk
@@ -9,7 +9,9 @@ rule nlr_parser:
         mem_mb = 2000
     conda:
         "../envs/meme.yaml"
+    log:
+        "logs/nlr_parser/{reference}.log"
     shell:
         """
-        java -jar ../utils/NLR-Parser3.jar -t {threads} -y $(which mast) -x ../utils/meme.xml -i {input} -o {output}
+        java -jar ../utils/NLR-Parser3.jar -t {threads} -y $(which mast) -x ../utils/meme.xml -i {input} -o {output} 2> {log}
         """

--- a/agrenseq/workflow/rules/phenotype.smk
+++ b/agrenseq/workflow/rules/phenotype.smk
@@ -5,7 +5,9 @@ rule phenotype:
         temp("results/phenotype.txt")
     resources:
         mem_mb = 1000
+    log:
+        "logs/phenotype/phenotype.log"
     shell:
         """
-        tail -n +2 {input} | cut --complement -f2,3 > {output}
+        tail -n +2 {input} | cut --complement -f2,3 1> {output} 2> {log}
         """

--- a/agrenseq/workflow/rules/plotting.smk
+++ b/agrenseq/workflow/rules/plotting.smk
@@ -45,7 +45,9 @@ rule plot:
         "../envs/plot.yaml"
     resources:
         mem_mb = 1000
+    log:
+        "logs/plot/{reference}.log"
     shell:
         """
-        Rscript --vanilla workflow/scripts/plot.R {input} {params.assoc_threshold} {wildcards.reference} {output.filtered} {output.plot}
+        Rscript --vanilla workflow/scripts/plot.R {input} {params.assoc_threshold} {wildcards.reference} {output.filtered} {output.plot} 2> {log}
         """

--- a/agrenseq/workflow/rules/plotting.smk
+++ b/agrenseq/workflow/rules/plotting.smk
@@ -7,9 +7,11 @@ rule sizes:
         "../envs/plot.yaml"
     resources:
         mem_mb = 1000
+    log:
+        "logs/sizes/sizes.log"
     shell:
         """
-        bioawk -c fastx '{{ print $name, length($seq) }}' {input.blast_genome} > {output.genome_size}
+        bioawk -c fastx '{{ print $name, length($seq) }}' {input.blast_genome} 1> {output.genome_size} 2> {log}
         """
 
 rule blast_plot:

--- a/agrenseq/workflow/rules/plotting.smk
+++ b/agrenseq/workflow/rules/plotting.smk
@@ -26,9 +26,11 @@ rule blast_plot:
         "../envs/plot.yaml"
     resources:
         mem_mb = 1000
+    log:
+        "logs/blast_plot/{reference}.log"
     shell:
         """
-        Rscript --vanilla workflow/scripts/blast_plot.R {input.genome_size} {input.blast_result} {input.filtered} {wildcards.reference} {output.plot}
+        Rscript --vanilla workflow/scripts/blast_plot.R {input.genome_size} {input.blast_result} {input.filtered} {wildcards.reference} {output.plot} 2> {log}
         """
 
 rule plot:

--- a/agrenseq/workflow/rules/run_association.smk
+++ b/agrenseq/workflow/rules/run_association.smk
@@ -12,7 +12,9 @@ rule run_association:
         mem_mb = 14000
     conda:
         "../envs/java.yaml"
+    log:
+        "logs/run_association/{reference}.log"
     shell:
         """
-        java -jar ../utils/AgRenSeq_RunAssociation.jar -i {input.matrix} -n {input.nlr} -p {input.phenotype} -a {input.assembly} -o {output}
+        java -jar ../utils/AgRenSeq_RunAssociation.jar -i {input.matrix} -n {input.nlr} -p {input.phenotype} -a {input.assembly} -o {output} 2> {log}
         """

--- a/agrenseq/workflow/rules/run_association.smk
+++ b/agrenseq/workflow/rules/run_association.smk
@@ -3,7 +3,7 @@ rule run_association:
         matrix = "results/output_matrix.txt",
         phenotype = "results/phenotype.txt",
         nlr = "results/{reference}_output.nlr.txt",
-	    assembly = get_reference
+        assembly = get_reference
     output:
         "results/{reference}_AgRenSeqResult.txt"
     threads:

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -265,9 +265,11 @@ rule nlr_annotator_baits:
         "envs/bedtools.yaml"
     resources:
         mem_mb = 1000
+    log:
+        "logs/nlr_annotator_baits/nlr_annotator_baits.log"
     shell:
         """
-        bedtools intersect -a {input.nlr_annotator_region} -b {input.baits_region} > {output}
+        bedtools intersect -a {input.nlr_annotator_region} -b {input.baits_region} 1> {output} 2> {log}
         """
 
 

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -339,7 +339,7 @@ rule per_gene_coverage:
         "logs/per_gene_coverage/{sample}.log"
     shell:
         """
-        cat {input.referenceGenes} | tail -n +2 | while read gene; do numPosWithCoverage=`grep -w "$gene" {input.sample_coverage} | awk '$6>0' | wc -l` 2> {log}; numPosTotal=`grep -w "$gene" {input.sample_coverage} | wc -l` 2>> {log}; if [ $numPosTotal -eq 0 ]; then echo "ERROR: gene $gene has CDS region of length zero. Check your input data (e.g. gene spelling in FASTA and CDS BED file) and retry.\nAborting pipeline run." >> {log}; exit; fi; pctCov=`awk "BEGIN {{print ($numPosWithCoverage/$numPosTotal)*100 }}"` 2>> {log}; echo -e "\n# covered positions for sample {wildcards.sample} in gene $gene: $numPosWithCoverage\n# CDS positions for gene $gene: $numPosTotal\npctCov: $pctCov" 2>> {log}; echo -e "$gene\t$pctCov" >> {output.gene_coverage} 2>> {log}; done
+        cat {input.referenceGenes} | tail -n +2 | while read gene; do numPosWithCoverage=`grep -w "$gene" {input.sample_coverage} | awk '$6>0' | wc -l` 2> {log}; numPosTotal=`grep -w "$gene" {input.sample_coverage} | wc -l` 2>> {log}; if [ $numPosTotal -eq 0 ]; then echo "ERROR: gene $gene has CDS region of length zero. Check your input data (e.g. gene spelling in FASTA and CDS BED file) and retry.\nAborting pipeline run." >> {log}; exit; fi; pctCov=`awk "BEGIN {{print ($numPosWithCoverage/$numPosTotal)*100 }}"` 2>> {log}; echo -e "\n# covered positions for sample {wildcards.sample} in gene $gene: $numPosWithCoverage\n# CDS positions for gene $gene: $numPosTotal\npctCov: $pctCov" 2>> {log}; echo -e "$gene\t$pctCov" 1>> {output.gene_coverage} 2>> {log}; done
         """
 
 
@@ -350,10 +350,12 @@ rule combine_gene_coverage:
         "coverage/{sample}_coverageValues.txt"
     resources:
         mem_mb = 1000
+    log:
+        "logs/combine_gene_coverage/{sample}.log"
     shell:
         """
-        echo {wildcards.sample} > {output}
-        cat {input} | cut -f2 >> {output}
+        echo {wildcards.sample} 1> {output} 2> {log}
+        cat {input} | cut -f2 1>> {output} 2>> {log}
         """
 
 

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -247,9 +247,11 @@ rule baits_region:
         "envs/bait_mapping.yaml"
     resources:
         mem_mb = 1000
+    log:
+        "logs/baits_region/baits_region.log"
     shell:
         """
-        Rscript workflow/script/RangeReduction.R {input.blast} {output} {params.flank} {input.headers} {input.fasta}
+        Rscript workflow/script/RangeReduction.R {input.blast} {output} {params.flank} {input.headers} {input.fasta} 2> {log}
         """
 
 

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -188,9 +188,11 @@ rule samtools_index_strict:
         "envs/bowtie2_samtools.yaml"
     resources:
         mem_mb = 1000
+    log:
+        "logs/samtools_index_strict/{sample}.log"
     shell:
         """
-        samtools index {input} {output}
+        samtools index {input} {output} 2> {log}
         """
 
 

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -286,7 +286,7 @@ rule bait_blast_check:
         stderr = "logs/bait_blast_check/bait_blast_check.log"
     run:
         import logging
-        logging.basicConfig(filename={log.stderr}, encoding='utf-8', level=logging.DEBUG)
+        logging.basicConfig(filename=log.stderr, encoding='utf-8', level=logging.DEBUG)
         bed_nlr = set()
 
         with open(input.bed) as f:
@@ -389,6 +389,6 @@ rule transpose_combined_coverage:
         "logs/transpose_combined_coverage/transpose_combined_coverage.log"
     run:
         import logging
-        logging.basicConfig(filename={log}, encoding='utf-8', level=logging.DEBUG)
+        logging.basicConfig(filename=log, encoding='utf-8', level=logging.DEBUG)
         df = pd.read_table(input[0], header = None)
         df.T.to_csv(output[0], sep = "\t", header = False, index = False)

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -335,9 +335,11 @@ rule per_gene_coverage:
         gene_coverage = "coverage/{sample}_geneCoverage.txt"
     resources:
         mem_mb = 1000
+    log:
+        "logs/per_gene_coverage/{sample}.log"
     shell:
         """
-        cat {input.referenceGenes} | tail -n +2 | while read gene; do numPosWithCoverage=`grep -w "$gene" {input.sample_coverage} | awk '$6>0' | wc -l`; numPosTotal=`grep -w "$gene" {input.sample_coverage} | wc -l`; if [ $numPosTotal -eq 0 ]; then echo "ERROR: gene $gene has CDS region of length zero. Check your input data (e.g. gene spelling in FASTA and CDS BED file) and retry.\nAborting pipeline run."; exit; fi; pctCov=`awk "BEGIN {{print ($numPosWithCoverage/$numPosTotal)*100 }}"`; echo -e "\n# covered positions for sample {wildcards.sample} in gene $gene: $numPosWithCoverage\n# CDS positions for gene $gene: $numPosTotal\npctCov: $pctCov"; echo -e "$gene\t$pctCov" >> {output.gene_coverage}; done
+        cat {input.referenceGenes} | tail -n +2 | while read gene; do numPosWithCoverage=`grep -w "$gene" {input.sample_coverage} | awk '$6>0' | wc -l` 2> {log}; numPosTotal=`grep -w "$gene" {input.sample_coverage} | wc -l` 2>> {log}; if [ $numPosTotal -eq 0 ]; then echo "ERROR: gene $gene has CDS region of length zero. Check your input data (e.g. gene spelling in FASTA and CDS BED file) and retry.\nAborting pipeline run." >> {log}; exit; fi; pctCov=`awk "BEGIN {{print ($numPosWithCoverage/$numPosTotal)*100 }}"` 2>> {log}; echo -e "\n# covered positions for sample {wildcards.sample} in gene $gene: $numPosWithCoverage\n# CDS positions for gene $gene: $numPosTotal\npctCov: $pctCov" 2>> {log}; echo -e "$gene\t$pctCov" >> {output.gene_coverage} 2>> {log}; done
         """
 
 

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -136,9 +136,11 @@ rule samtools_sort:
         temp("mappings/{sample}_sorted.bam")
     conda:
         "envs/bowtie2_samtools.yaml"
+    log:
+        "logs/samtools_sort/{sample}.log"
     shell:
         """
-        samtools sort --threads {threads} -l 9 {input} -o {output}
+        samtools sort --threads {threads} -l 9 {input} -o {output} 2> {log}
         """
 
 

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -369,10 +369,12 @@ rule combine_coverage_values:
         ulimit = config["ulimit"]
     resources:
         mem_mb = 1000
+    log:
+        "logs/combine_coverage_values/combine_coverage_values.log"
     shell:
         """
-        ulimit -n {params.ulimit}
-        paste {input.gene_names} {input.coverage} > {output}
+        ulimit -n {params.ulimit} 2> {log}
+        paste {input.gene_names} {input.coverage} 1> {output} 2>> {log}
         """
 
 

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -282,8 +282,11 @@ rule bait_blast_check:
     resources:
         mem_mb = 1000
     log:
-        missed_genes = "baits_mapping/missed_genes.txt"
+        missed_genes = "baits_mapping/missed_genes.txt",
+        stderr = "logs/bait_blast_check/bait_blast_check.log"
     run:
+        import logging
+        logging.basicConfig(filename={log.stderr}, encoding='utf-8', level=logging.DEBUG)
         bed_nlr = set()
 
         with open(input.bed) as f:

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -117,9 +117,11 @@ rule bowtie_align:
         "envs/bowtie2_samtools.yaml"
     output:
         temp("tmp_mappings/{sample}.bam")
+    log:
+        "logs/bowtie_align/{sample}.log"
     shell:
         """
-        bowtie2 -x {input.ref} -1 {input.FRead} -2 {input.RRead} --rg-id {params.rg_id} --rg {params.rg} -p {threads} --score-min {params.score} --phred33 --fr --maxins 1000 --very-sensitive --no-unal --no-discordant -k {params.max_align} | samtools view --threads {threads} -S -b > {output}
+        bowtie2 -x {input.ref} -1 {input.FRead} -2 {input.RRead} --rg-id {params.rg_id} --rg {params.rg} -p {threads} --score-min {params.score} --phred33 --fr --maxins 1000 --very-sensitive --no-unal --no-discordant -k {params.max_align} | samtools view --threads {threads} -S -b 1> {output} 2> {log}
         """
 
 

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -205,9 +205,11 @@ rule baits_mapping_db:
         "envs/blast.yaml"
     resources:
         mem_mb = 1000
+    log:
+        "logs/baits_mapping_db/baits_mapping_db.log"
     shell:
         """
-        makeblastdb -in {input.ref} -out "baits_mapping/baits_mapping_db" -dbtype nucl
+        makeblastdb -in {input.ref} -out "baits_mapping/baits_mapping_db" -dbtype nucl 2> {log}
         """
 
 

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -171,9 +171,11 @@ rule sambamba_filter:
         "envs/sambamba.yaml"
     resources:
         mem_mb = 1000
+    log:
+        "logs/sambamba_filter/{sample}.log"
     shell:
         """
-        sambamba view --format=bam -l 9 --filter='[NM] == 0' -o {output} {input.bam}
+        sambamba view --format=bam -l 9 --filter='[NM] == 0' -o {output} {input.bam} 2> {log}
         """
 
 

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -48,11 +48,13 @@ rule extract_reference_headers:
         contigs = "resources/reference_headers_contigs.txt"
     resources:
         mem_mb = 1000
+    log:
+        "logs/extract_reference_headers/extract_reference_headers.log"
     shell:
         """
-        echo "gene" > {output.nlrs}
-        cat {input.bed} | cut -f4 >> {output.nlrs}
-        cat {input.fasta} | grep '>' | sed 's/>//g' > {output.contigs}
+        echo "gene" 1> {output.nlrs} 2> {log}
+        cat {input.bed} | cut -f4 1>> {output.nlrs} 2>> {log}
+        cat {input.fasta} | grep '>' | sed 's/>//g' 1> {output.contigs} 2>> {log}
         """
 
 

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -226,9 +226,11 @@ rule baits_mapping:
         "envs/blast.yaml"
     resources:
         mem_mb = 1000
+    log:
+        "logs/baits_mapping/baits_mapping.log"
     shell:
         """
-        blastn -db "baits_mapping/baits_mapping_db" -query {input.baits} -out {output} -perc_identity {params.identity} -qcov_hsp_perc {params.coverage} -evalue 1e-5 -outfmt '6 qseqid sseqid pident length mismatch gapopen qstart qend sstart send evalue bitscore qlen len qcovs qcovhsp'
+        blastn -db "baits_mapping/baits_mapping_db" -query {input.baits} -out {output} -perc_identity {params.identity} -qcov_hsp_perc {params.coverage} -evalue 1e-5 -outfmt '6 qseqid sseqid pident length mismatch gapopen qstart qend sstart send evalue bitscore qlen len qcovs qcovhsp' 2> {log}
         """
 
 

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -153,9 +153,11 @@ rule samtools_index_relaxed:
         "envs/bowtie2_samtools.yaml"
     resources:
         mem_mb = 1000
+    log:
+        "logs/samtools_index_relaxed/{sample}.log"
     shell:
         """
-        samtools index {input} {output}
+        samtools index {input} {output} 2> {log}
         """
 
 

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -90,9 +90,11 @@ rule bowtie_build:
         "envs/bowtie2_samtools.yaml"
     resources:
         mem_mb = 1000
+    log:
+        "logs/bowtie_build/bowtie_build.log"
     shell:
         """
-        bowtie2-build {input} {input}
+        bowtie2-build {input} {input} 2> {log}
         """
 
 

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -286,7 +286,7 @@ rule bait_blast_check:
         stderr = "logs/bait_blast_check/bait_blast_check.log"
     run:
         import logging
-        logging.basicConfig(filename=log.stderr, encoding='utf-8', level=logging.DEBUG)
+        logging.basicConfig(filename=str(log.stderr), encoding='utf-8', level=logging.DEBUG)
         bed_nlr = set()
 
         with open(input.bed) as f:
@@ -389,6 +389,6 @@ rule transpose_combined_coverage:
         "logs/transpose_combined_coverage/transpose_combined_coverage.log"
     run:
         import logging
-        logging.basicConfig(filename=log, encoding='utf-8', level=logging.DEBUG)
+        logging.basicConfig(filename=str(log), encoding='utf-8', level=logging.DEBUG)
         df = pd.read_table(input[0], header = None)
         df.T.to_csv(output[0], sep = "\t", header = False, index = False)

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -73,9 +73,11 @@ rule trim_read_remove_adaptor:
         mem_mb = 2000
     conda:
         "envs/cutadapt.yaml"
+    log:
+        "logs/trim_read_remove_adaptor/{sample}.log"
     shell:
         """
-        cutadapt --cores {threads} --minimum-length 50 -q 20,20 -a file:{input.adaptor_1} -A file:{input.adaptor_2} -o {output.trimF} -p {output.trimR} {input.fastqF} {input.fastqR}
+        cutadapt --cores {threads} --minimum-length 50 -q 20,20 -a file:{input.adaptor_1} -A file:{input.adaptor_2} -o {output.trimF} -p {output.trimR} {input.fastqF} {input.fastqR} 2> {log}
         """
 
 

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -385,6 +385,10 @@ rule transpose_combined_coverage:
         "coverage/all_coverage_values_transposed.txt"
     resources:
         mem_mb = 1000
+    log:
+        "logs/transpose_combined_coverage/transpose_combined_coverage.log"
     run:
+        import logging
+        logging.basicConfig(filename={log}, encoding='utf-8', level=logging.DEBUG)
         df = pd.read_table(input[0], header = None)
         df.T.to_csv(output[0], sep = "\t", header = False, index = False)

--- a/drenseq/workflow/Snakefile
+++ b/drenseq/workflow/Snakefile
@@ -319,9 +319,11 @@ rule coverage_strict:
         "envs/bedtools.yaml"
     resources:
         mem_mb = 1000
+    log:
+        "logs/coverage_strict/{sample}.log"
     shell:
         """
-        coverageBed -d -a {input.bed} -b {input.bam} > {output}
+        coverageBed -d -a {input.bed} -b {input.bam} 1> {output} 2> {log}
         """
 
 

--- a/smrtrenseq_assembly/workflow/Snakefile
+++ b/smrtrenseq_assembly/workflow/Snakefile
@@ -156,7 +156,11 @@ rule summarise_NLRs:
         "NLR_Annotator/NLR_summary.txt"
     resources:
         mem_mb = 1000
+    log:
+        "logs/summarise_NLRs/summarise_NLRs.log"
     run:
+        import logging
+        logging.basicConfig(filename={log}, encoding='utf-8', level=logging.DEBUG)
         with open(output[0], "w") as o:
             header_list = ["Sample", "NLR Contigs", "NLR Count", "Pseudogenous NLRs", "NLR Genes", "Complete NLRs", "Complete Pseudogenous NLRs"]
             header_string = "\t".join(header_list)

--- a/smrtrenseq_assembly/workflow/Snakefile
+++ b/smrtrenseq_assembly/workflow/Snakefile
@@ -260,8 +260,10 @@ rule map_hifi:
     conda:
         "envs/minimap2.yaml"
     resources:
-        partition = "medium",
+        slurm_partition = "medium",
         mem_mb = 4000
+    log:
+        "logs/map_hifi/{sample}.log"
     shell:
         """
         minimap2 -x map-hifi -t {threads} -a -o {output} {input.assembly} {input.reads}

--- a/smrtrenseq_assembly/workflow/Snakefile
+++ b/smrtrenseq_assembly/workflow/Snakefile
@@ -226,9 +226,11 @@ rule convert_nlrs_to_bed:
         temp("NLR_Annotator/{sample}_NLR_Annotator.bed")
     resources:
         mem_mb = 1000
+    log:
+        "logs/convert_nlrs_to_bed/{sample}.log"
     shell:
         """
-        python3 workflow/scripts/NLR_Annotator_to_bed.py --input {input} --output {output}
+        python3 workflow/scripts/NLR_Annotator_to_bed.py --input {input} --output {output} 2> {log}
         """
 
 

--- a/smrtrenseq_assembly/workflow/Snakefile
+++ b/smrtrenseq_assembly/workflow/Snakefile
@@ -42,10 +42,12 @@ rule trim_reads:
         "envs/cutadapt.yaml"
     resources:
         mem_mb = 1000
+    log:
+        "logs/trim_reads/{sample}.log"
     shell:
         """
-        cutadapt -j {threads} -g ^{params.fiveprime} -o {output.intermediate} {input}
-        cutadapt -j {threads} -a {params.threeprime}$ -o {output.fq} {output.intermediate}
+        cutadapt -j {threads} -g ^{params.fiveprime} -o {output.intermediate} {input} 2> {log}
+        cutadapt -j {threads} -a {params.threeprime}$ -o {output.fq} {output.intermediate} 2>> {log}
         """
 
 

--- a/smrtrenseq_assembly/workflow/Snakefile
+++ b/smrtrenseq_assembly/workflow/Snakefile
@@ -313,9 +313,11 @@ rule index_sorted_bam:
         "envs/samtools.yaml"
     resources:
         mem_mb = 1000
+    log:
+        "logs/index_sorted_bam/{sample}.log"
     shell:
         """
-        samtools index {input} {output}
+        samtools index {input} {output} 2> {log}
         """
 
 

--- a/smrtrenseq_assembly/workflow/Snakefile
+++ b/smrtrenseq_assembly/workflow/Snakefile
@@ -347,7 +347,9 @@ rule parse_coverage:
         "NLR_coverage/{sample}_coverage_parsed.txt"
     resources:
         mem_mb = 1000
+    log:
+        "logs/parse_coverage/{sample}.log"
     shell:
         """
-        python workflow/scripts/parse_coverage.py --input {input} --output {output}
+        python workflow/scripts/parse_coverage.py --input {input} --output {output} 2> {log}
         """

--- a/smrtrenseq_assembly/workflow/Snakefile
+++ b/smrtrenseq_assembly/workflow/Snakefile
@@ -88,7 +88,7 @@ rule summarise_assemblies:
         "logs/summarise_assemblies/summarise_assemblies.log"
     shell:
         """
-        seqfu stats -b {input} | sed 's/\.contigs//g' 1> {output} 2> {log}
+        seqfu stats -b {input} | sed 's/\\.contigs//g' 1> {output} 2> {log}
         """
 
 

--- a/smrtrenseq_assembly/workflow/Snakefile
+++ b/smrtrenseq_assembly/workflow/Snakefile
@@ -181,7 +181,7 @@ rule summarise_NLRs:
             for line in lines:
                 count += 1
                 line = line.rstrip()
-                split_line = line.split('\t')
+                split_line = line.split(r'\t')
                 nlr_type = split_line[2]
                 contig = split_line[0]
                 contig_set.add(contig)

--- a/smrtrenseq_assembly/workflow/Snakefile
+++ b/smrtrenseq_assembly/workflow/Snakefile
@@ -84,9 +84,11 @@ rule summarise_assemblies:
         "envs/seqfu.yaml"
     resources:
         mem_mb = 1000
+    log:
+        "logs/summarise_assemblies/summarise_assemblies.log"
     shell:
         """
-        seqfu stats -b {input} | sed 's/\.contigs//g' > {output}
+        seqfu stats -b {input} | sed 's/\.contigs//g' 1> {output} 2> {log}
         """
 
 

--- a/smrtrenseq_assembly/workflow/Snakefile
+++ b/smrtrenseq_assembly/workflow/Snakefile
@@ -181,7 +181,7 @@ rule summarise_NLRs:
             for line in lines:
                 count += 1
                 line = line.rstrip()
-                split_line = line.split(r'\t')
+                split_line = line.split('\t')
                 nlr_type = split_line[2]
                 contig = split_line[0]
                 contig_set.add(contig)

--- a/smrtrenseq_assembly/workflow/Snakefile
+++ b/smrtrenseq_assembly/workflow/Snakefile
@@ -160,7 +160,7 @@ rule summarise_NLRs:
         "logs/summarise_NLRs/summarise_NLRs.log"
     run:
         import logging
-        logging.basicConfig(filename={log}, encoding='utf-8', level=logging.DEBUG)
+        logging.basicConfig(filename=log, encoding='utf-8', level=logging.DEBUG)
         with open(output[0], "w") as o:
             header_list = ["Sample", "NLR Contigs", "NLR Count", "Pseudogenous NLRs", "NLR Genes", "Complete NLRs", "Complete Pseudogenous NLRs"]
             header_string = "\t".join(header_list)

--- a/smrtrenseq_assembly/workflow/Snakefile
+++ b/smrtrenseq_assembly/workflow/Snakefile
@@ -141,9 +141,11 @@ rule run_NLR_Annotator:
         mem_mb = 2000
     conda:
         "envs/meme.yaml"
+    log:
+        "logs/run_NLR_Annotator/{sample}.log"
     shell:
         """
-        java -jar ../utils/NLR-Annotator.jar -i {input.parser_xml} -o {output.text} -f {input.assembly} {output.fasta} {params.flanking}
+        java -jar ../utils/NLR-Annotator.jar -i {input.parser_xml} -o {output.text} -f {input.assembly} {output.fasta} {params.flanking} 2> {log}
         """
 
 

--- a/smrtrenseq_assembly/workflow/Snakefile
+++ b/smrtrenseq_assembly/workflow/Snakefile
@@ -160,7 +160,7 @@ rule summarise_NLRs:
         "logs/summarise_NLRs/summarise_NLRs.log"
     run:
         import logging
-        logging.basicConfig(filename=log, encoding='utf-8', level=logging.DEBUG)
+        logging.basicConfig(filename=str(log), encoding='utf-8', level=logging.DEBUG)
         with open(output[0], "w") as o:
             header_list = ["Sample", "NLR Contigs", "NLR Count", "Pseudogenous NLRs", "NLR Genes", "Complete NLRs", "Complete Pseudogenous NLRs"]
             header_string = "\t".join(header_list)

--- a/smrtrenseq_assembly/workflow/Snakefile
+++ b/smrtrenseq_assembly/workflow/Snakefile
@@ -101,9 +101,11 @@ rule chop_sequences:
         "envs/meme.yaml"
     resources:
         mem_mb = 2000
+    log:
+        "logs/chop_sequences/{sample}.log"
     shell:
         """
-        java -jar ../utils/ChopSequence.jar -i {input} -o {output}
+        java -jar ../utils/ChopSequence.jar -i {input} -o {output} 2> {log}
         """
 
 

--- a/smrtrenseq_assembly/workflow/Snakefile
+++ b/smrtrenseq_assembly/workflow/Snakefile
@@ -65,11 +65,13 @@ rule canu_assemble:
     conda:
         "envs/canu.yaml"
     resources:
-        mem_mb = 10000,
-        partition = "medium"
+        mem_mb = 36000,
+        slurm_partition = "long"
+    log:
+        "logs/canu_assemble/{sample}.log"
     shell:
         """
-        canu -d assembly/{wildcards.sample} -p {params.Prefix} -pacbio-hifi {input} useGrid=false genomeSize={params.Genome_Size} maxInputCoverage=10000
+        canu -d assembly/{wildcards.sample} -p {params.Prefix} -pacbio-hifi {input} useGrid=false genomeSize={params.Genome_Size} maxInputCoverage=20000 batMemory=32g 2> {log}
         """
 
 

--- a/smrtrenseq_assembly/workflow/Snakefile
+++ b/smrtrenseq_assembly/workflow/Snakefile
@@ -279,9 +279,11 @@ rule convert_sam_to_bam:
         "envs/samtools.yaml"
     resources:
         mem_mb = 1000
+    log:
+        "logs/convert_sam_to_bam/{sample}.log"
     shell:
         """
-        samtools view -F 256 {input} -b -o {output}
+        samtools view -F 256 {input} -b -o {output} 2> {log}
         """
 
 

--- a/smrtrenseq_assembly/workflow/Snakefile
+++ b/smrtrenseq_assembly/workflow/Snakefile
@@ -209,11 +209,13 @@ rule input_statistics:
         "assembly/{sample}_input_stats.txt"
     resources:
         mem_mb = 1000
+    log:
+        "logs/input_statistics/{sample}.log"
     shell:
         """
-        Reads=$(cat {input} | grep -m 1 'reads' | cut -f5 -d ' ')
-        Bases=$(cat {input} | grep -m 1 'bases' | cut -f5 -d ' ')
-        printf "{wildcards.sample}\t$Reads\t$Bases" > {output}
+        Reads=$(cat {input} | grep -m 1 'reads' | cut -f5 -d ' ') 2> {log}
+        Bases=$(cat {input} | grep -m 1 'bases' | cut -f5 -d ' ') 2>> {log}
+        printf "{wildcards.sample}\t$Reads\t$Bases" 1> {output} 2>> {log}
         """
 
 

--- a/smrtrenseq_assembly/workflow/Snakefile
+++ b/smrtrenseq_assembly/workflow/Snakefile
@@ -241,9 +241,11 @@ rule sort_nlr_bed:
         "NLR_Annotator/{sample}_NLR_Annotator_sorted.bed"
     resources:
         mem_mb = 1000
+    log:
+        "logs/sort_nlr_bed/{sample}.log"
     shell:
         """
-        sort -k1,1V -k2,2n -k3,3n {input} > {output}
+        sort -k1,1V -k2,2n -k3,3n {input} 1> {output} 2> {log}
         """
 
 

--- a/smrtrenseq_assembly/workflow/Snakefile
+++ b/smrtrenseq_assembly/workflow/Snakefile
@@ -120,9 +120,11 @@ rule NLR_parser:
         mem_mb = 3000
     conda:
         "envs/meme.yaml"
+    log:
+        "logs/NLR_parser/{sample}.log"
     shell:
         """
-        java -jar ../utils/NLR-Parser3.jar -t {threads} -y $(which mast) -x ../utils/meme.xml -i {input} -c {output}
+        java -jar ../utils/NLR-Parser3.jar -t {threads} -y $(which mast) -x ../utils/meme.xml -i {input} -c {output} 2> {log}
         """
 
 

--- a/smrtrenseq_assembly/workflow/Snakefile
+++ b/smrtrenseq_assembly/workflow/Snakefile
@@ -332,9 +332,11 @@ rule calculate_coverage:
         "envs/samtools.yaml"
     resources:
         mem_mb = 1000
+    log:
+        "logs/calculate_coverage/{sample}.log"
     shell:
         """
-        samtools bedcov {input.bed} {input.bam} > {output}
+        samtools bedcov {input.bed} {input.bam} 1> {output} 2> {log}
         """
 
 

--- a/smrtrenseq_assembly/workflow/Snakefile
+++ b/smrtrenseq_assembly/workflow/Snakefile
@@ -296,9 +296,11 @@ rule sort_bam:
         "envs/samtools.yaml"
     resources:
         mem_mb = 2000
+    log:
+        "logs/sort_bam/{sample}.log"
     shell:
         """
-        samtools sort {input} > {output}
+        samtools sort {input} 1> {output} 2> {log}
         """
 
 


### PR DESCRIPTION
This PR provides basic compatability with Snakemake 8 and above. Outstanding backwards compatability issues with profiles will be resolved if fixes become available to improve ease of use, however this restores the majority of the functionality.

Logging has been temporarily added through redirects of stderr to log files, it doesn't quite replicate what the slurm profile did, but it's unclear if the profile can be updated to reproduce this behaviour due to the changes made by Snakemake 8.