### PR TITLE
Canu log files are blank

### DIFF
--- a/smrtrenseq_assembly/workflow/Snakefile
+++ b/smrtrenseq_assembly/workflow/Snakefile
@@ -67,11 +67,9 @@ rule canu_assemble:
     resources:
         mem_mb = 36000,
         slurm_partition = "long"
-    log:
-        "logs/canu_assemble/{sample}.log"
     shell:
         """
-        canu -d assembly/{wildcards.sample} -p {params.Prefix} -pacbio-hifi {input} useGrid=false genomeSize={params.Genome_Size} maxInputCoverage=20000 batMemory=32g 2> {log}
+        canu -d assembly/{wildcards.sample} -p {params.Prefix} -pacbio-hifi {input} useGrid=false genomeSize={params.Genome_Size} maxInputCoverage=20000 batMemory=32g
         """
 
 


### PR DESCRIPTION
Canu's log files are created by redirecting the stderr. Our logging also works by redirecting stderr so it breaks downstream rules and causes the workflow to crash. This small patch means there is no manual logging for the canu assemble rule, but allow further steps to work as designed.